### PR TITLE
Support worktrees with paths not matching their name

### DIFF
--- a/src/bare_repo.rs
+++ b/src/bare_repo.rs
@@ -1,14 +1,18 @@
-use crate::{commands::git_command, utils::merged_branches, Context};
+use crate::{
+    commands::git_command,
+    utils::get_all_worktree_names,
+    Context,
+};
 
-pub fn clean_merged_branches(context: &Context) -> Result<(), String> {
-    let branches = merged_branches(&context.main_branch_name, &context.repo_path)
-        .expect("Couldn't get the list of merged branches");
+pub fn clean_merged_worktrees(context: &Context) -> Result<(), String> {
+    let worktrees = get_all_worktree_names(&context.repo_path)
+        .expect("Couldn't get the list of merged worktrees");
 
-    for branch in branches {
-        if worktree_is_clean(context, &branch) {
-            match delete_worktree(context, &branch) {
-                Ok(_) => println!("Deleted worktree: {}", branch),
-                Err(msg) => println!("Couldn't delete worktree '{}', error: {}", branch, msg)
+    for worktree in worktrees {
+        if (worktree != context.main_branch_name) && worktree_is_clean(context, &worktree) {
+            match delete_worktree(context, &worktree) {
+                Ok(_) => println!("Deleted worktree: {}", worktree),
+                Err(msg) => println!("Couldn't delete worktree '{}', error: {}", worktree, msg),
             }
         }
     }

--- a/src/bare_repo.rs
+++ b/src/bare_repo.rs
@@ -20,7 +20,6 @@ pub fn clean_merged_worktrees(context: &Context) -> Result<(), String> {
 }
 
 fn delete_worktree(context: &Context, worktree: &Worktree) -> Result<(), String> {
-    println!("worktree: {:?}", worktree);
     match git_command(
         vec!["worktree", "remove", &worktree.path],
         context.repo_path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod bare_repo;
 mod commands;
 mod normal_repo;
 mod utils;
+mod worktree;
 mod worktree_list_item;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
 
     match get_command() {
         AvailableCommands::CleanMergedBranches => match context.repo_type {
-            RepoType::Bare => match bare_repo::clean_merged_branches(&context) {
+            RepoType::Bare => match bare_repo::clean_merged_worktrees(&context) {
                 Ok(_) => (),
                 Err(msg) => {
                     println!("Error: {}", msg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod bare_repo;
 mod commands;
 mod normal_repo;
 mod utils;
+mod worktree_list_item;
 
 #[cfg(test)]
 mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -97,10 +97,6 @@ fn test_not_deleting_current_head_branch_leaves_repo_with_the_same_branch_checke
             test_helpers::assert_current_branch(&context, "unmerged".to_string());
         },
     );
-
-    test_helpers::run_setup(
-        "test_not_deleting_current_head_branch_leaves_repo_with_the_same_branch_checked_out",
-    );
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 mod test_helpers;
 mod test_setup;
 
-use crate::commands::git_command;
+use crate::{commands::git_command, utils::get_all_worktrees, worktree::Worktree};
 
 use self::test_helpers::run_test;
 use super::*;
@@ -151,6 +151,42 @@ fn test_main_worktree_is_not_removed() {
             bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
 
             test_helpers::assert_worktree_exists(context, "main".to_string());
+        },
+    );
+}
+
+#[test]
+fn test_worktree_list_is_parsed_correctly() {
+    run_test(
+        "test_worktree_list_is_parsed_correctly",
+        test_setup::BARE_REPO_NAME,
+        RepoType::Bare,
+        |context| {
+            let worktrees = get_all_worktrees(&context).expect("Couldn't get all worktrees");
+            let expected = vec![
+                Worktree {
+                    name: "dirty".to_string(),
+                    path: "dirty".to_string(),
+                },
+                Worktree {
+                    name: "main".to_string(),
+                    path: "main".to_string(),
+                },
+                Worktree {
+                    name: "merged".to_string(),
+                    path: "merged".to_string(),
+                },
+                Worktree {
+                    name: "other-branch".to_string(),
+                    path: "origin/other-branch".to_string(),
+                },
+                Worktree {
+                    name: "unmerged".to_string(),
+                    path: "unmerged".to_string(),
+                },
+            ];
+
+            assert_eq!(expected, worktrees);
         },
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,7 +103,7 @@ fn test_not_deleting_current_head_branch_leaves_repo_with_the_same_branch_checke
 fn test_dirty_worktrees_are_not_removed() {
     run_test(
         "test_dirty_worktrees_are_not_removed",
-        "bare_repo",
+        test_setup::BARE_REPO_NAME,
         RepoType::Bare,
         |context| {
             bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
@@ -117,7 +117,7 @@ fn test_dirty_worktrees_are_not_removed() {
 fn test_unmerged_worktrees_are_not_removed() {
     run_test(
         "test_unmerged_worktrees_are_not_removed",
-        "bare_repo",
+        test_setup::BARE_REPO_NAME,
         RepoType::Bare,
         |context| {
             bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
@@ -131,7 +131,7 @@ fn test_unmerged_worktrees_are_not_removed() {
 fn test_merged_worktrees_are_removed() {
     run_test(
         "test_merged_worktrees_are_removed",
-        "bare_repo",
+        test_setup::BARE_REPO_NAME,
         RepoType::Bare,
         |context| {
             bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
@@ -145,7 +145,7 @@ fn test_merged_worktrees_are_removed() {
 fn test_main_worktree_is_not_removed() {
     run_test(
         "test_main_worktree_is_not_removed",
-        "bare_repo",
+        test_setup::BARE_REPO_NAME,
         RepoType::Bare,
         |context| {
             bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -110,7 +110,7 @@ fn test_dirty_worktrees_are_not_removed() {
         "bare_repo",
         RepoType::Bare,
         |context| {
-            bare_repo::clean_merged_branches(&context).expect("failed to clean merged branches");
+            bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
 
             test_helpers::assert_worktree_exists(context, "dirty".to_string());
         },
@@ -124,7 +124,7 @@ fn test_unmerged_worktrees_are_not_removed() {
         "bare_repo",
         RepoType::Bare,
         |context| {
-            bare_repo::clean_merged_branches(&context).expect("failed to clean merged branches");
+            bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
 
             test_helpers::assert_worktree_exists(context, "unmerged".to_string());
         },
@@ -138,7 +138,7 @@ fn test_merged_worktrees_are_removed() {
         "bare_repo",
         RepoType::Bare,
         |context| {
-            bare_repo::clean_merged_branches(&context).expect("failed to clean merged branches");
+            bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
 
             test_helpers::assert_worktree_does_not_exist(context, "merged".to_string());
         },
@@ -152,7 +152,7 @@ fn test_main_worktree_is_not_removed() {
         "bare_repo",
         RepoType::Bare,
         |context| {
-            bare_repo::clean_merged_branches(&context).expect("failed to clean merged branches");
+            bare_repo::clean_merged_worktrees(&context).expect("failed to clean merged branches");
 
             test_helpers::assert_worktree_exists(context, "main".to_string());
         },

--- a/src/tests/test_helpers.rs
+++ b/src/tests/test_helpers.rs
@@ -2,7 +2,7 @@ use std::{env::current_dir, path::PathBuf};
 
 use crate::{
     tests::test_setup::{setup, teardown},
-    utils::{get_all_branch_names, get_current_branch_name, get_all_worktree_names},
+    utils::{get_all_branch_names, get_current_branch_name, get_all_worktrees},
     Context, RepoType
 };
 
@@ -18,10 +18,10 @@ pub fn assert_branch_does_not_exist(context: Context, branch: String) {
     assert!(!get_all_branch_names(&context.repo_path).contains(&branch));
 }
 
-pub fn assert_worktree_does_not_exist(context: Context, worktree: String) {
-    let worktrees = get_all_worktree_names(&context.repo_path).expect("Couldn't get list of worktrees");
+pub fn assert_worktree_does_not_exist(context: Context, worktree_name: String) {
+    let worktrees = get_all_worktrees(&context).expect("Couldn't get list of worktrees");
 
-    assert!(!worktrees.contains(&worktree));
+    assert!(!worktrees.iter().any(|w| w.name == worktree_name));
 }
 
 pub fn assert_current_branch(context: &Context, branch: String) {

--- a/src/tests/test_helpers.rs
+++ b/src/tests/test_helpers.rs
@@ -1,36 +1,10 @@
-use std::{env::current_dir, path::PathBuf, str::Split};
+use std::{env::current_dir, path::PathBuf};
 
 use crate::{
     tests::test_setup::{setup, teardown},
-    utils::{get_all_branch_names, get_current_branch_name},
-    Context, RepoType, commands::git_command,
+    utils::{get_all_branch_names, get_current_branch_name, get_all_worktree_names},
+    Context, RepoType
 };
-
-fn clean_worktree_name(worktree: &String) -> Option<String> {
-    let mut parts: Split<char> = worktree.as_str().split('[');
-
-    if parts.clone().count() < 2 {
-        return None;
-    }
-
-    let name = parts
-        .next_back()
-        .expect("Couldn't get second item")
-        .strip_suffix(']')
-        .expect("Couldn't strip suffix")
-        .to_string();
-
-    Some(name)
-}
-
-pub fn get_all_worktree_names(repo_path: &PathBuf) -> Vec<String> {
-    git_command(vec!["worktree", "list"], PathBuf::from(repo_path))
-        .expect("Couldn't get worktree names")
-        .output
-        .iter()
-        .filter_map(clean_worktree_name)
-        .collect::<Vec<String>>()
-}
 
 pub fn assert_branches(context: Context, branches: Vec<String>) {
     assert_eq!(get_all_branch_names(&context.repo_path), branches);
@@ -45,7 +19,9 @@ pub fn assert_branch_does_not_exist(context: Context, branch: String) {
 }
 
 pub fn assert_worktree_does_not_exist(context: Context, worktree: String) {
-    assert!(!get_all_worktree_names(&context.repo_path).contains(&worktree));
+    let worktrees = get_all_worktree_names(&context.repo_path).expect("Couldn't get list of worktrees");
+
+    assert!(!worktrees.contains(&worktree));
 }
 
 pub fn assert_current_branch(context: &Context, branch: String) {

--- a/src/tests/test_setup.rs
+++ b/src/tests/test_setup.rs
@@ -1,5 +1,7 @@
 use std::{error::Error, process::Command};
 
+pub const BARE_REPO_NAME: &str = "abc";
+
 pub fn setup(test_name: &str) -> Result<(), Box<dyn Error>> {
     // make sure we start with a clean slate even of a previous test failed
     teardown(test_name)?;
@@ -14,7 +16,7 @@ pub fn setup(test_name: &str) -> Result<(), Box<dyn Error>> {
 fn create_bare_repo(test_name: &str) -> Result<(), Box<dyn Error>> {
     Command::new("mkdir")
         .arg("-p")
-        .arg(format!("dummy_repos/{}/bare_repo", test_name))
+        .arg(format!("dummy_repos/{}/{}", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("mkdir")
@@ -56,7 +58,7 @@ fn create_bare_repo(test_name: &str) -> Result<(), Box<dyn Error>> {
         .arg("clone")
         .arg("--bare")
         .arg(format!("dummy_repos/{}/bare_repo_source", test_name))
-        .arg(format!("dummy_repos/{}/bare_repo", test_name))
+        .arg(format!("dummy_repos/{}/{}", test_name, BARE_REPO_NAME))
         .output()?;
 
     Ok(())
@@ -68,7 +70,7 @@ fn create_worktree(
     worktree_path: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
     let mut command = Command::new("git");
-    command.current_dir(format!("dummy_repos/{}/bare_repo", test_name));
+    command.current_dir(format!("dummy_repos/{}/{}", test_name, BARE_REPO_NAME));
     command.arg("worktree").arg("add");
 
     if let Some(path) = worktree_path {
@@ -88,49 +90,49 @@ fn setup_worktrees(test_name: &str) -> Result<(), Box<dyn Error>> {
 
     Command::new("touch")
         .arg("uncommitted-file")
-        .current_dir(format!("dummy_repos/{}/bare_repo/dirty", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/dirty", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("touch")
         .arg("unmerged-file")
-        .current_dir(format!("dummy_repos/{}/bare_repo/unmerged", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/unmerged", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("git")
         .arg("add")
         .arg("unmerged-file")
-        .current_dir(format!("dummy_repos/{}/bare_repo/unmerged", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/unmerged", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("git")
         .arg("commit")
         .arg("-m")
         .arg("file that won't be merged")
-        .current_dir(format!("dummy_repos/{}/bare_repo/unmerged", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/unmerged", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("touch")
         .arg("merged-file")
-        .current_dir(format!("dummy_repos/{}/bare_repo/merged", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/merged", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("git")
         .arg("add")
         .arg("merged-file")
-        .current_dir(format!("dummy_repos/{}/bare_repo/merged", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/merged", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("git")
         .arg("commit")
         .arg("-m")
         .arg("file that will be merged")
-        .current_dir(format!("dummy_repos/{}/bare_repo/merged", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/merged", test_name, BARE_REPO_NAME))
         .output()?;
 
     Command::new("git")
         .arg("merge")
         .arg("merged")
-        .current_dir(format!("dummy_repos/{}/bare_repo/main", test_name))
+        .current_dir(format!("dummy_repos/{}/{}/main", test_name, BARE_REPO_NAME))
         .output()?;
 
     Ok(())

--- a/src/tests/test_setup.rs
+++ b/src/tests/test_setup.rs
@@ -19,49 +19,44 @@ fn create_bare_repo(test_name: &str) -> Result<(), Box<dyn Error>> {
 
     Command::new("mkdir")
         .arg("-p")
-        .arg(format!("dummy_repos/{}/bare_repo.tmp", test_name))
+        .arg(format!("dummy_repos/{}/bare_repo_source", test_name))
         .output()?;
 
     Command::new("git")
         .arg("init")
-        .current_dir(format!("dummy_repos/{}/bare_repo.tmp", test_name))
+        .current_dir(format!("dummy_repos/{}/bare_repo_source", test_name))
         .output()?;
 
     Command::new("touch")
         .arg("README.md")
-        .current_dir(format!("dummy_repos/{}/bare_repo.tmp", test_name))
+        .current_dir(format!("dummy_repos/{}/bare_repo_source", test_name))
         .output()?;
 
     Command::new("git")
         .arg("add")
         .arg("README.md")
-        .current_dir(format!("dummy_repos/{}/bare_repo.tmp", test_name))
+        .current_dir(format!("dummy_repos/{}/bare_repo_source", test_name))
         .output()?;
 
     Command::new("git")
         .arg("commit")
         .arg("-m")
         .arg("commit readme")
-        .current_dir(format!("dummy_repos/{}/bare_repo.tmp", test_name))
+        .current_dir(format!("dummy_repos/{}/bare_repo_source", test_name))
+        .output()?;
+
+    Command::new("git")
+        .arg("checkout")
+        .arg("-b")
+        .arg("other-branch")
+        .current_dir(format!("dummy_repos/{}/bare_repo_source", test_name))
         .output()?;
 
     Command::new("git")
         .arg("clone")
         .arg("--bare")
-        .arg(format!("dummy_repos/{}/bare_repo.tmp", test_name))
+        .arg(format!("dummy_repos/{}/bare_repo_source", test_name))
         .arg(format!("dummy_repos/{}/bare_repo", test_name))
-        .output()?;
-
-    Command::new("git")
-        .arg("remote")
-        .arg("rm")
-        .arg("origin")
-        .current_dir(format!("dummy_repos/{}/bare_repo", test_name))
-        .output()?;
-
-    Command::new("rm")
-        .arg("-rf")
-        .arg(format!("dummy_repos/{}/bare_repo.tmp", test_name))
         .output()?;
 
     Ok(())

--- a/src/tests/test_setup.rs
+++ b/src/tests/test_setup.rs
@@ -87,6 +87,7 @@ fn setup_worktrees(test_name: &str) -> Result<(), Box<dyn Error>> {
     create_worktree(test_name, "dirty", None)?;
     create_worktree(test_name, "unmerged", None)?;
     create_worktree(test_name, "merged", None)?;
+    create_worktree(test_name, "other-branch", Some("origin/other-branch"))?;
 
     Command::new("touch")
         .arg("uncommitted-file")

--- a/src/tests/test_setup.rs
+++ b/src/tests/test_setup.rs
@@ -62,31 +62,33 @@ fn create_bare_repo(test_name: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn setup_worktrees(test_name: &str) -> Result<(), Box<dyn Error>> {
-    Command::new("git")
-        .arg("worktree")
-        .arg("add")
-        .arg("main")
-        .current_dir(format!("dummy_repos/{}/bare_repo", test_name))
-        .output()?;
+fn create_worktree(
+    test_name: &str,
+    worktree_name: &str,
+    worktree_path: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let mut command = Command::new("git");
+    command.current_dir(format!("dummy_repos/{}/bare_repo", test_name));
+    command.arg("worktree").arg("add");
 
-    Command::new("git")
-        .arg("worktree")
-        .arg("add")
-        .arg("dirty")
-        .current_dir(format!("dummy_repos/{}/bare_repo", test_name))
-        .output()?;
+    if let Some(path) = worktree_path {
+        command.arg(path);
+    }
+
+    command.arg(worktree_name).output()?;
+
+    Ok(())
+}
+
+fn setup_worktrees(test_name: &str) -> Result<(), Box<dyn Error>> {
+    create_worktree(test_name, "main", None)?;
+    create_worktree(test_name, "dirty", None)?;
+    create_worktree(test_name, "unmerged", None)?;
+    create_worktree(test_name, "merged", None)?;
 
     Command::new("touch")
         .arg("uncommitted-file")
         .current_dir(format!("dummy_repos/{}/bare_repo/dirty", test_name))
-        .output()?;
-
-    Command::new("git")
-        .arg("worktree")
-        .arg("add")
-        .arg("unmerged")
-        .current_dir(format!("dummy_repos/{}/bare_repo", test_name))
         .output()?;
 
     Command::new("touch")
@@ -105,13 +107,6 @@ fn setup_worktrees(test_name: &str) -> Result<(), Box<dyn Error>> {
         .arg("-m")
         .arg("file that won't be merged")
         .current_dir(format!("dummy_repos/{}/bare_repo/unmerged", test_name))
-        .output()?;
-
-    Command::new("git")
-        .arg("worktree")
-        .arg("add")
-        .arg("merged")
-        .current_dir(format!("dummy_repos/{}/bare_repo", test_name))
         .output()?;
 
     Command::new("touch")

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,0 +1,24 @@
+use crate::worktree_list_item::WorktreeListItem;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Worktree {
+    path: String,
+    name: String,
+}
+
+impl<'a> TryFrom<&WorktreeListItem<'a>> for Worktree {
+    type Error = &'static str;
+
+    fn try_from(list_item: &WorktreeListItem) -> Result<Self, Self::Error> {
+        if list_item.is_bare() {
+            return Err("Can't create a Worktree from a bare WorktreeListItem");
+        }
+
+        Ok(Self {
+            name: list_item.name().expect("Couldn't get list item name"),
+            path: list_item.path().expect("Couldn't get list item path"),
+        })
+    }
+}
+
+mod tests;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -2,8 +2,8 @@ use crate::worktree_list_item::WorktreeListItem;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Worktree {
-    path: String,
-    name: String,
+    pub path: String,
+    pub name: String,
 }
 
 impl<'a> TryFrom<&WorktreeListItem<'a>> for Worktree {
@@ -12,6 +12,10 @@ impl<'a> TryFrom<&WorktreeListItem<'a>> for Worktree {
     fn try_from(list_item: &WorktreeListItem) -> Result<Self, Self::Error> {
         if list_item.is_bare() {
             return Err("Can't create a Worktree from a bare WorktreeListItem");
+        }
+
+        if list_item.is_detached() {
+            return Err("Can't create a Worktree from a detached WorktreeListItem");
         }
 
         Ok(Self {

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -22,3 +22,13 @@ fn test_worktree_cannot_be_created_from_a_bare_worktree_list_item() {
     );
     super::Worktree::try_from(&item).expect_err("Shouldn't have created a worktree, but did");
 }
+
+#[test]
+fn test_worktree_cannot_be_created_from_a_detached_worktree_list_item() {
+    let repo_path = PathBuf::from("/a/repo");
+    let item = super::WorktreeListItem::new(
+        &repo_path,
+        "/a/repo  (detached HEAD)",
+    );
+    super::Worktree::try_from(&item).expect_err("Shouldn't have created a worktree, but did");
+}

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -1,7 +1,10 @@
+use std::path::PathBuf;
+
 #[test]
 fn test_worktree_can_be_created_from_a_worktree_list_item() {
+    let repo_path = PathBuf::from("/a/repo");
     let item = super::WorktreeListItem::new(
-        "/a/repo",
+        &repo_path,
         "/a/repo/origin/some-work     f9e08b4 [some-work]",
     );
     let worktree = super::Worktree::try_from(&item).expect("Couldn't create a worktree");
@@ -12,8 +15,9 @@ fn test_worktree_can_be_created_from_a_worktree_list_item() {
 
 #[test]
 fn test_worktree_cannot_be_created_from_a_bare_worktree_list_item() {
+    let repo_path = PathBuf::from("/a/repo");
     let item = super::WorktreeListItem::new(
-        "/a/repo",
+        &repo_path,
         "/a/repo  (bare)",
     );
     super::Worktree::try_from(&item).expect_err("Shouldn't have created a worktree, but did");

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -1,0 +1,20 @@
+#[test]
+fn test_worktree_can_be_created_from_a_worktree_list_item() {
+    let item = super::WorktreeListItem::new(
+        "/a/repo",
+        "/a/repo/origin/some-work     f9e08b4 [some-work]",
+    );
+    let worktree = super::Worktree::try_from(&item).expect("Couldn't create a worktree");
+
+    assert_eq!("origin/some-work", worktree.path);
+    assert_eq!("some-work", worktree.name);
+}
+
+#[test]
+fn test_worktree_cannot_be_created_from_a_bare_worktree_list_item() {
+    let item = super::WorktreeListItem::new(
+        "/a/repo",
+        "/a/repo  (bare)",
+    );
+    super::Worktree::try_from(&item).expect_err("Shouldn't have created a worktree, but did");
+}

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -53,8 +53,9 @@ impl<'a> WorktreeListItem<'a> {
 
         let name_portion = self.output_split_on_left_square_bracket().1;
         let worktree_name = name_portion
-            .strip_suffix(']')
-            .expect("Couldn't strip suffix");
+            .rsplit_once(']')
+            .expect("Couldn't split on ']'")
+            .0;
 
         Some(worktree_name.to_string())
     }
@@ -63,10 +64,14 @@ impl<'a> WorktreeListItem<'a> {
         self.list_item_output.ends_with("(bare)")
     }
 
+    pub fn is_detached(&self) -> bool {
+        self.list_item_output.ends_with("(detached HEAD)")
+    }
+
     fn output_split_on_left_square_bracket(&self) -> (&str, &str) {
         self.list_item_output
             .split_once('[')
-            .expect("Couldn't split '{}' on '['")
+            .expect(format!("Couldn't split '{}' on '['", self.list_item_output).as_str())
     }
 }
 

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+// This is a way to store one line from `git worktree list` so that it can be easily coerced into a
+// Worktree
+pub struct WorktreeListItem<'a> {
+    repo_path: &'a str,
+    list_item_output: &'a str,
+}
+
+impl<'a> WorktreeListItem<'a> {
+    fn path(&self) -> Option<String> {
+        if self.is_bare() {
+            return None;
+        }
+
+        let path_portion = self.output_split_on_left_square_bracket().0;
+        let worktree_path = path_portion.trim();
+        let absolute_path = worktree_path
+            .rsplit_once(' ')
+            .expect(
+                format!(
+                    "Couldn't split on a space, does a space exist? (string: '{}')",
+                    worktree_path
+                )
+                .as_str(),
+            )
+            .0
+            .trim();
+
+        let relative_path = Path::new(absolute_path)
+            .strip_prefix(self.repo_path)
+            .expect("Couldn't strip repo path from full path");
+
+        Some(
+            relative_path
+                .to_str()
+                .expect("Couldn't convert path to str")
+                .to_string(),
+        )
+    }
+
+    fn name(&self) -> Option<String> {
+        if self.is_bare() {
+            return None;
+        }
+
+        let name_portion = self.output_split_on_left_square_bracket().1;
+        let worktree_name = name_portion
+            .strip_suffix(']')
+            .expect("Couldn't strip suffix");
+
+        Some(worktree_name.to_string())
+    }
+
+    fn is_bare(&self) -> bool {
+        self.list_item_output.ends_with("(bare)")
+    }
+
+    fn output_split_on_left_square_bracket(&self) -> (&str, &str) {
+        self.list_item_output
+            .split_once('[')
+            .expect("Couldn't split '{}' on '['")
+    }
+}
+
+mod tests;

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -8,14 +8,14 @@ pub struct WorktreeListItem<'a> {
 }
 
 impl<'a> WorktreeListItem<'a> {
-    fn new(repo_path: &'a str, list_item_output: &'a str) -> Self {
+    pub fn new(repo_path: &'a str, list_item_output: &'a str) -> Self {
         Self {
             list_item_output,
             repo_path,
         }
     }
 
-    fn path(&self) -> Option<String> {
+    pub fn path(&self) -> Option<String> {
         if self.is_bare() {
             return None;
         }
@@ -46,7 +46,7 @@ impl<'a> WorktreeListItem<'a> {
         )
     }
 
-    fn name(&self) -> Option<String> {
+    pub fn name(&self) -> Option<String> {
         if self.is_bare() {
             return None;
         }
@@ -59,7 +59,7 @@ impl<'a> WorktreeListItem<'a> {
         Some(worktree_name.to_string())
     }
 
-    fn is_bare(&self) -> bool {
+    pub fn is_bare(&self) -> bool {
         self.list_item_output.ends_with("(bare)")
     }
 

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -8,6 +8,13 @@ pub struct WorktreeListItem<'a> {
 }
 
 impl<'a> WorktreeListItem<'a> {
+    fn new(repo_path: &'a str, list_item_output: &'a str) -> Self {
+        Self {
+            list_item_output,
+            repo_path,
+        }
+    }
+
     fn path(&self) -> Option<String> {
         if self.is_bare() {
             return None;

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -1,14 +1,14 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // This is a way to store one line from `git worktree list` so that it can be easily coerced into a
 // Worktree
 pub struct WorktreeListItem<'a> {
-    repo_path: &'a str,
+    repo_path: &'a PathBuf,
     list_item_output: &'a str,
 }
 
 impl<'a> WorktreeListItem<'a> {
-    pub fn new(repo_path: &'a str, list_item_output: &'a str) -> Self {
+    pub fn new(repo_path: &'a PathBuf, list_item_output: &'a str) -> Self {
         Self {
             list_item_output,
             repo_path,

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -39,6 +39,16 @@ fn test_path_worktree_path_and_repo_path_can_include_symbols() {
 }
 
 #[test]
+fn test_path_can_have_a_subdirectory() {
+    let item = WorktreeListItem::new(
+        "/a/repo",
+        "/a/repo/origin/some-work     f9e08b4 [some-work]",
+    );
+
+    assert_eq!(Some("origin/some-work".to_string()), item.path());
+}
+
+#[test]
 fn test_path_is_none_for_the_root_list_item() {
     let item = WorktreeListItem::new(
         "/a/repo with-_ ^symbols",

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -2,10 +2,7 @@ use super::WorktreeListItem;
 
 #[test]
 fn test_path_output_does_not_include_repo_path() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo/some-work f9e08b4 [some-work]")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work f9e08b4 [some-work]");
 
     println!("item.path(): {:?}", item.path());
     assert_eq!(Some("some-work".to_string()), item.path());
@@ -13,110 +10,89 @@ fn test_path_output_does_not_include_repo_path() {
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_spaces() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo with  spaces"),
-        list_item_output: &String::from("/a/repo with  spaces/some-work f9e08b4 [some-work]")
-    };
+    let item = WorktreeListItem::new(
+        "/a/repo with  spaces",
+        "/a/repo with  spaces/some-work f9e08b4 [some-work]",
+    );
 
     assert_eq!(Some("some-work".to_string()), item.path());
 }
 
 #[test]
 fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo with  spaces"),
-        list_item_output: &String::from("/a/repo with  spaces/some-work     f9e08b4 [some-work]")
-    };
+    let item = WorktreeListItem::new(
+        "/a/repo with  spaces",
+        "/a/repo with  spaces/some-work     f9e08b4 [some-work]",
+    );
 
     assert_eq!(Some("some-work".to_string()), item.path());
 }
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_symbols() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo with-_ ^symbols"),
-        list_item_output: &String::from("/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]")
-    };
+    let item = WorktreeListItem::new(
+        "/a/repo with-_ ^symbols",
+        "/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]",
+    );
 
     assert_eq!(Some("some-work".to_string()), item.path());
 }
 
 #[test]
 fn test_path_is_none_for_the_root_list_item() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo with-_ ^symbols"),
-        list_item_output: &String::from("/a/repo with-_ ^symbols    (bare)")
-    };
+    let item = WorktreeListItem::new(
+        "/a/repo with-_ ^symbols",
+        "/a/repo with-_ ^symbols    (bare)",
+    );
 
     assert_eq!(None, item.path());
 }
 
 #[test]
 fn test_name_can_include_symbols() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some-_^wo[rk]]")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some-_^wo[rk]]");
 
     assert_eq!(Some("some-_^wo[rk]".to_string()), item.name());
 }
 
 #[test]
 fn test_name_can_include_spaces() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some work]")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some work]");
 
     assert_eq!(Some("some work".to_string()), item.name());
 }
 
 #[test]
 fn test_name_can_include_forward_slashes() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some/work]")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some/work]");
 
     assert_eq!(Some("some/work".to_string()), item.name());
 }
 
 #[test]
 fn test_name_can_include_backslashes() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some\\work]")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some\\work]");
 
     assert_eq!(Some("some\\work".to_string()), item.name());
 }
 
 #[test]
 fn test_name_is_none_for_the_root_list_item() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo    (bare)")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo    (bare)");
 
     assert_eq!(None, item.name());
 }
 
 #[test]
 fn test_is_bare_is_true_for_the_root_list_item() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo    (bare)")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo    (bare)");
 
     assert!(item.is_bare());
 }
 
 #[test]
 fn test_is_bare_is_false_for_a_non_root_list_item() {
-    let item = WorktreeListItem {
-        repo_path: &String::from("/a/repo"),
-        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some-work]")
-    };
+    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some-work]");
 
     assert!(!item.is_bare());
 }

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -7,7 +7,6 @@ fn test_path_output_does_not_include_repo_path() {
     let repo_path = PathBuf::from("/a/repo");
     let item = WorktreeListItem::new(&repo_path, "/a/repo/some-work f9e08b4 [some-work]");
 
-    println!("item.path(): {:?}", item.path());
     assert_eq!(Some("some-work".to_string()), item.path());
 }
 

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -1,0 +1,122 @@
+use super::WorktreeListItem;
+
+#[test]
+fn test_path_output_does_not_include_repo_path() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo/some-work f9e08b4 [some-work]")
+    };
+
+    println!("item.path(): {:?}", item.path());
+    assert_eq!(Some("some-work".to_string()), item.path());
+}
+
+#[test]
+fn test_path_worktree_path_and_repo_path_can_include_spaces() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo with  spaces"),
+        list_item_output: &String::from("/a/repo with  spaces/some-work f9e08b4 [some-work]")
+    };
+
+    assert_eq!(Some("some-work".to_string()), item.path());
+}
+
+#[test]
+fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo with  spaces"),
+        list_item_output: &String::from("/a/repo with  spaces/some-work     f9e08b4 [some-work]")
+    };
+
+    assert_eq!(Some("some-work".to_string()), item.path());
+}
+
+#[test]
+fn test_path_worktree_path_and_repo_path_can_include_symbols() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo with-_ ^symbols"),
+        list_item_output: &String::from("/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]")
+    };
+
+    assert_eq!(Some("some-work".to_string()), item.path());
+}
+
+#[test]
+fn test_path_is_none_for_the_root_list_item() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo with-_ ^symbols"),
+        list_item_output: &String::from("/a/repo with-_ ^symbols    (bare)")
+    };
+
+    assert_eq!(None, item.path());
+}
+
+#[test]
+fn test_name_can_include_symbols() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some-_^wo[rk]]")
+    };
+
+    assert_eq!(Some("some-_^wo[rk]".to_string()), item.name());
+}
+
+#[test]
+fn test_name_can_include_spaces() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some work]")
+    };
+
+    assert_eq!(Some("some work".to_string()), item.name());
+}
+
+#[test]
+fn test_name_can_include_forward_slashes() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some/work]")
+    };
+
+    assert_eq!(Some("some/work".to_string()), item.name());
+}
+
+#[test]
+fn test_name_can_include_backslashes() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some\\work]")
+    };
+
+    assert_eq!(Some("some\\work".to_string()), item.name());
+}
+
+#[test]
+fn test_name_is_none_for_the_root_list_item() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo    (bare)")
+    };
+
+    assert_eq!(None, item.name());
+}
+
+#[test]
+fn test_is_bare_is_true_for_the_root_list_item() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo    (bare)")
+    };
+
+    assert!(item.is_bare());
+}
+
+#[test]
+fn test_is_bare_is_false_for_a_non_root_list_item() {
+    let item = WorktreeListItem {
+        repo_path: &String::from("/a/repo"),
+        list_item_output: &String::from("/a/repo/some-work     f9e08b4 [some-work]")
+    };
+
+    assert!(!item.is_bare());
+}

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -1,8 +1,11 @@
+use std::path::PathBuf;
+
 use super::WorktreeListItem;
 
 #[test]
 fn test_path_output_does_not_include_repo_path() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work f9e08b4 [some-work]");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(&repo_path, "/a/repo/some-work f9e08b4 [some-work]");
 
     println!("item.path(): {:?}", item.path());
     assert_eq!(Some("some-work".to_string()), item.path());
@@ -10,8 +13,9 @@ fn test_path_output_does_not_include_repo_path() {
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_spaces() {
+    let repo_path = PathBuf::from("/a/repo with  spaces");
     let item = WorktreeListItem::new(
-        "/a/repo with  spaces",
+        &repo_path,
         "/a/repo with  spaces/some-work f9e08b4 [some-work]",
     );
 
@@ -20,8 +24,9 @@ fn test_path_worktree_path_and_repo_path_can_include_spaces() {
 
 #[test]
 fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
+    let repo_path = PathBuf::from("/a/repo with  spaces");
     let item = WorktreeListItem::new(
-        "/a/repo with  spaces",
+        &repo_path,
         "/a/repo with  spaces/some-work     f9e08b4 [some-work]",
     );
 
@@ -30,8 +35,9 @@ fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_symbols() {
+    let repo_path = PathBuf::from("/a/repo with-_ ^symbols");
     let item = WorktreeListItem::new(
-        "/a/repo with-_ ^symbols",
+        &repo_path,
         "/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]",
     );
 
@@ -40,8 +46,9 @@ fn test_path_worktree_path_and_repo_path_can_include_symbols() {
 
 #[test]
 fn test_path_can_have_a_subdirectory() {
+    let repo_path = PathBuf::from("/a/repo");
     let item = WorktreeListItem::new(
-        "/a/repo",
+        &repo_path,
         "/a/repo/origin/some-work     f9e08b4 [some-work]",
     );
 
@@ -50,8 +57,9 @@ fn test_path_can_have_a_subdirectory() {
 
 #[test]
 fn test_path_is_none_for_the_root_list_item() {
+    let repo_path = PathBuf::from("/a/repo with-_ ^symbols");
     let item = WorktreeListItem::new(
-        "/a/repo with-_ ^symbols",
+        &repo_path,
         "/a/repo with-_ ^symbols    (bare)",
     );
 
@@ -60,49 +68,105 @@ fn test_path_is_none_for_the_root_list_item() {
 
 #[test]
 fn test_name_can_include_symbols() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some-_^wo[rk]]");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some-work     f9e08b4 [some-_^wo[rk]]",
+    );
 
     assert_eq!(Some("some-_^wo[rk]".to_string()), item.name());
 }
 
 #[test]
 fn test_name_can_include_spaces() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some work]");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some-work     f9e08b4 [some work]",
+    );
 
     assert_eq!(Some("some work".to_string()), item.name());
 }
 
 #[test]
 fn test_name_can_include_forward_slashes() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some/work]");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some-work     f9e08b4 [some/work]",
+    );
 
     assert_eq!(Some("some/work".to_string()), item.name());
 }
 
 #[test]
 fn test_name_can_include_backslashes() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some\\work]");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some-work     f9e08b4 [some\\work]",
+    );
 
     assert_eq!(Some("some\\work".to_string()), item.name());
 }
 
 #[test]
 fn test_name_is_none_for_the_root_list_item() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo    (bare)");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(&repo_path, "/a/repo    (bare)");
 
     assert_eq!(None, item.name());
 }
 
 #[test]
 fn test_is_bare_is_true_for_the_root_list_item() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo    (bare)");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(&repo_path, "/a/repo    (bare)");
 
     assert!(item.is_bare());
 }
 
 #[test]
 fn test_is_bare_is_false_for_a_non_root_list_item() {
-    let item = WorktreeListItem::new("/a/repo", "/a/repo/some-work     f9e08b4 [some-work]");
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some-work     f9e08b4 [some-work]",
+    );
 
     assert!(!item.is_bare());
+}
+
+#[test]
+fn test_is_detached_is_true_if_list_item_is_detached() {
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/dirty                0000000 (detached HEAD)",
+    );
+
+    assert!(item.is_detached());
+}
+
+#[test]
+fn test_is_detached_is_false_if_list_item_is_not_detached() {
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some-work     f9e08b4 [some-work]",
+    );
+
+    assert!(!item.is_detached());
+}
+
+#[test]
+fn test_prunable_worktree_is_parsed_properly() {
+    let repo_path = PathBuf::from("/a/repo");
+    let item = WorktreeListItem::new(
+        &repo_path,
+        "/a/repo/some  work in a prunable worktree    f9e08b4 [some-work] prunable",
+    );
+
+    assert_eq!("some-work", item.name().expect("Couldn't parse name"));
+    assert_eq!("some  work in a prunable worktree", item.path().expect("Couldn't parse path"));
 }


### PR DESCRIPTION
This PR adds support for worktrees that have a name which doesn't match their path. For example, a worktree that is checkout out from a remote will have the remote's name in the path. Checking out "some-branch" from "origin" might result in a worktree path of "origin/some-branch".