### PR TITLE
Delete worktrees using their absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ unexpected branch or worktree are deleted.
 
 - [X] Removing a worktree should also delete the related branch. This should work for worktrees that have paths which
   don't match their branch name as well.
-- [ ] When parsing `git worktree --list`, use the whole path instead of just the relative path. This will remove logic
-  that splits out the relative path, and should also support unconventional repository structures. The current
-  implementation assumes that worktrees are stored as subdirectories of the repo root, but that doesn't have to be the
-  case.
+- [X] When parsing `git worktree --list`, use the whole path instead of just the relative path.
 - [ ] Add a "dry run" mode so that you can see what will be deleted
 - [ ] Remove as many object duplications (`clone()`/`to_owned()`) as possible
 - [ ] Fix CI -- `git checkout`/`git commit` don't seem to work correctly, so the dummy repos don't get setup correctly

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -181,8 +181,6 @@ fn test_branches_are_removed_for_worktrees_that_are_removed_when_path_doesnt_mat
             test_helpers::assert_worktree_exists(bare_repo, "wont-match-path".to_string());
             test_helpers::assert_branch_exists(&repo, "wont-match-path".to_string());
 
-
-
             RepositoryInterface::clean_merged(bare_repo).expect("failed to clean merged worktrees");
 
             test_helpers::assert_worktree_does_not_exist(bare_repo, "wont-match-path".to_string());
@@ -224,32 +222,32 @@ fn test_worktree_list_is_parsed_correctly() {
             let expected = vec![
                 Worktree {
                     name: "dirty".to_string(),
-                    path: "dirty".to_string(),
+                    path: "/Users/brandoncc/dev/git-tools/dummy_repos/test_worktree_list_is_parsed_correctly/bare repo  -_^^ with symbols and spaces/dirty".to_string(),
                     repository: bare_repo,
                 },
                 Worktree {
                     name: "main".to_string(),
-                    path: "main".to_string(),
+                    path: "/Users/brandoncc/dev/git-tools/dummy_repos/test_worktree_list_is_parsed_correctly/bare repo  -_^^ with symbols and spaces/main".to_string(),
                     repository: bare_repo,
                 },
                 Worktree {
                     name: "merged".to_string(),
-                    path: "merged".to_string(),
+                    path: "/Users/brandoncc/dev/git-tools/dummy_repos/test_worktree_list_is_parsed_correctly/bare repo  -_^^ with symbols and spaces/merged".to_string(),
                     repository: bare_repo,
                 },
                 Worktree {
                     name: "wont-match-path".to_string(),
-                    path: "origin/doesnt-match-name".to_string(),
+                    path: "/Users/brandoncc/dev/git-tools/dummy_repos/test_worktree_list_is_parsed_correctly/bare repo  -_^^ with symbols and spaces/origin/doesnt-match-name".to_string(),
                     repository: bare_repo,
                 },
                 Worktree {
                     name: "other-branch".to_string(),
-                    path: "origin/other-branch".to_string(),
+                    path: "/Users/brandoncc/dev/git-tools/dummy_repos/test_worktree_list_is_parsed_correctly/bare repo  -_^^ with symbols and spaces/origin/other-branch".to_string(),
                     repository: bare_repo,
                 },
                 Worktree {
                     name: "unmerged".to_string(),
-                    path: "unmerged".to_string(),
+                    path: "/Users/brandoncc/dev/git-tools/dummy_repos/test_worktree_list_is_parsed_correctly/bare repo  -_^^ with symbols and spaces/unmerged".to_string(),
                     repository: bare_repo,
                 },
             ];

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -16,7 +16,7 @@ fn test_worktree_can_be_created_from_a_worktree_list_item() {
     let item = WorktreeListItem::new(&repo, "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string());
     let worktree = super::Worktree::try_from(item).expect("Couldn't create a worktree");
 
-    assert_eq!("origin/some-work", worktree.path);
+    assert_eq!("/a/repo/origin/some-work", worktree.path);
     assert_eq!("some-work", worktree.name);
 }
 

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-
-use crate::repository::{BareRepository, RepositoryInterface};
+use crate::repository::BareRepository;
 
 // This is a way to store one line from `git worktree list` so that it can be easily coerced into a
 // Worktree
@@ -37,16 +35,7 @@ impl<'a> WorktreeListItem<'a> {
             .0
             .trim();
 
-        let relative_path = Path::new(absolute_path)
-            .strip_prefix(RepositoryInterface::root(self.repository))
-            .expect("Couldn't strip repo path from full path");
-
-        Some(
-            relative_path
-                .to_str()
-                .expect("Couldn't convert path to str")
-                .to_string(),
-        )
+        Some(absolute_path.to_string())
     }
 
     pub fn name(&self) -> Option<String> {

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -15,7 +15,7 @@ fn test_path_output_does_not_include_repo_path() {
     };
     let item = WorktreeListItem::new(&repo, "/a/repo/some-work f9e08b4 [some-work]".to_string());
 
-    assert_eq!(Some("some-work".to_string()), item.path());
+    assert_eq!(Some("/a/repo/some-work".to_string()), item.path());
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn test_path_worktree_path_and_repo_path_can_include_spaces() {
     };
     let item = WorktreeListItem::new(&repo, "/a/repo with  spaces/some-work f9e08b4 [some-work]".to_string());
 
-    assert_eq!(Some("some-work".to_string()), item.path());
+    assert_eq!(Some("/a/repo with  spaces/some-work".to_string()), item.path());
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
         "/a/repo with  spaces/some-work     f9e08b4 [some-work]".to_string(),
     );
 
-    assert_eq!(Some("some-work".to_string()), item.path());
+    assert_eq!(Some("/a/repo with  spaces/some-work".to_string()), item.path());
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_path_worktree_path_and_repo_path_can_include_symbols() {
         "/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]".to_string(),
     );
 
-    assert_eq!(Some("some-work".to_string()), item.path());
+    assert_eq!(Some("/a/repo with-_ ^symbols/some-work".to_string()), item.path());
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn test_path_can_have_a_subdirectory() {
     };
     let item = WorktreeListItem::new(&repo, "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string());
 
-    assert_eq!(Some("origin/some-work".to_string()), item.path());
+    assert_eq!(Some("/a/repo/origin/some-work".to_string()), item.path());
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn test_prunable_worktree_is_parsed_properly() {
 
     assert_eq!("some-work", item.name().expect("Couldn't parse name"));
     assert_eq!(
-        "some  work in a prunable worktree",
+        "/a/repo/some  work in a prunable worktree",
         item.path().expect("Couldn't parse path")
     );
 }


### PR DESCRIPTION
### What it is

When instantiating `Worktree` structs, use the absolute path rather than the relative path. This allows us to delete worktrees that exist anywhere on the file system. This allows the application to support unconventional directory structures for bare repositories.