### PR TITLE
Fix test runs on linux (including CI)

### DIFF
--- a/src/repository/tests.rs
+++ b/src/repository/tests.rs
@@ -7,12 +7,17 @@ use std::fs::create_dir;
 #[cfg(test)]
 use std::path::PathBuf;
 
+#[cfg(test)]
 use crate::repository::{all_branch_names, RepositoryInterface};
+
 #[cfg(test)]
 use crate::repository::{BareRepository, NormalRepository};
 
 #[cfg(test)]
 use crate::test_helpers::run_test;
+
+#[cfg(test)]
+use crate::test_setup::DEFAULT_BRANCH_NAME;
 
 #[cfg(test)]
 use crate::test_setup::{BARE_REPO_NAME, CLEAN_NORMAL_REPO_NAME};
@@ -112,7 +117,10 @@ fn test_bare_repository_at_with_subdirectory_has_correct_main_branch_name() {
             let repo2 = BareRepository::at(&path)
                 .unwrap_or_else(|| panic!("{:#?} is not a valid git repository", &path));
 
-            assert_eq!("main", RepositoryInterface::main_branch_name(&repo2));
+            assert_eq!(
+                DEFAULT_BRANCH_NAME,
+                RepositoryInterface::main_branch_name(&repo2)
+            );
         },
     );
 }
@@ -126,7 +134,7 @@ fn test_bare_repository_at_with_root_has_correct_main_branch_name() {
             let repo2 = BareRepository::at(repo.root())
                 .unwrap_or_else(|| panic!("{:#?} is not a valid git repository", repo.root()));
 
-            assert_eq!("main", repo2.main_branch_name);
+            assert_eq!(DEFAULT_BRANCH_NAME, repo2.main_branch_name);
         },
     );
 }
@@ -189,7 +197,7 @@ fn test_normal_repository_at_with_subdirectory_has_correct_main_branch_name() {
             let repo = NormalRepository::at(&path)
                 .unwrap_or_else(|| panic!("{:#?} is not a valid git repository", &path));
 
-            assert_eq!("main", repo.main_branch_name);
+            assert_eq!(DEFAULT_BRANCH_NAME, repo.main_branch_name);
         },
     );
 }
@@ -203,7 +211,7 @@ fn test_normal_repository_at_with_root_has_correct_main_branch_name() {
             let repo = NormalRepository::at(repo.root())
                 .unwrap_or_else(|| panic!("{:#?} is not a valid git repository", &repo.root()));
 
-            assert_eq!("main", repo.main_branch_name);
+            assert_eq!(DEFAULT_BRANCH_NAME, repo.main_branch_name);
         },
     );
 }
@@ -234,7 +242,7 @@ fn test_all_branch_names_returns_correct_list() {
             let names = all_branch_names(repo.root());
             println!("names: {:?}", names);
 
-            assert_eq!(vec!["main", "merged", "unmerged"], names);
+            assert_eq!(vec![DEFAULT_BRANCH_NAME, "merged", "unmerged"], names);
         },
     );
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -75,3 +75,9 @@ pub fn run_test(test_name: &str, repo_directory: &str, test: fn(Box<dyn Reposito
     test(repository);
     run_teardown(test_name);
 }
+
+pub fn as_bare_repo(repo: &Box<dyn RepositoryInterface>) -> &BareRepository {
+    repo.as_any()
+        .downcast_ref::<BareRepository>()
+        .expect("Should have been a BareRepository, but wasn't")
+}

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -5,15 +5,21 @@ use std::path::PathBuf;
 use crate::repository::BareRepository;
 
 #[cfg(test)]
+use crate::test_setup::DEFAULT_BRANCH_NAME;
+
+#[cfg(test)]
 use crate::worktree::WorktreeListItem;
 
 #[test]
 fn test_worktree_can_be_created_from_a_worktree_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string(),
+    );
     let worktree = super::Worktree::try_from(item).expect("Couldn't create a worktree");
 
     assert_eq!("/a/repo/origin/some-work", worktree.path);
@@ -24,7 +30,7 @@ fn test_worktree_can_be_created_from_a_worktree_list_item() {
 fn test_worktree_cannot_be_created_from_a_bare_worktree_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = super::WorktreeListItem::new(&repo, "/a/repo  (bare)".to_string());
     super::Worktree::try_from(item).expect_err("Shouldn't have created a worktree, but did");
@@ -34,7 +40,7 @@ fn test_worktree_cannot_be_created_from_a_bare_worktree_list_item() {
 fn test_worktree_cannot_be_created_from_a_detached_worktree_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = super::WorktreeListItem::new(&repo, "/a/repo  (detached HEAD)".to_string());
     super::Worktree::try_from(item).expect_err("Shouldn't have created a worktree, but did");

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -5,13 +5,16 @@ use std::path::PathBuf;
 use crate::repository::BareRepository;
 
 #[cfg(test)]
+use crate::test_setup::DEFAULT_BRANCH_NAME;
+
+#[cfg(test)]
 use super::WorktreeListItem;
 
 #[test]
 fn test_path_output_does_not_include_repo_path() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(&repo, "/a/repo/some-work f9e08b4 [some-work]".to_string());
 
@@ -22,48 +25,63 @@ fn test_path_output_does_not_include_repo_path() {
 fn test_path_worktree_path_and_repo_path_can_include_spaces() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo with  spaces"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo with  spaces/some-work f9e08b4 [some-work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo with  spaces/some-work f9e08b4 [some-work]".to_string(),
+    );
 
-    assert_eq!(Some("/a/repo with  spaces/some-work".to_string()), item.path());
+    assert_eq!(
+        Some("/a/repo with  spaces/some-work".to_string()),
+        item.path()
+    );
 }
 
 #[test]
 fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo with  spaces"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo with  spaces/some-work     f9e08b4 [some-work]".to_string(),
     );
 
-    assert_eq!(Some("/a/repo with  spaces/some-work".to_string()), item.path());
+    assert_eq!(
+        Some("/a/repo with  spaces/some-work".to_string()),
+        item.path()
+    );
 }
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_symbols() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo with-_ ^symbols"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]".to_string(),
     );
 
-    assert_eq!(Some("/a/repo with-_ ^symbols/some-work".to_string()), item.path());
+    assert_eq!(
+        Some("/a/repo with-_ ^symbols/some-work".to_string()),
+        item.path()
+    );
 }
 
 #[test]
 fn test_path_can_have_a_subdirectory() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string(),
+    );
 
     assert_eq!(Some("/a/repo/origin/some-work".to_string()), item.path());
 }
@@ -72,7 +90,7 @@ fn test_path_can_have_a_subdirectory() {
 fn test_path_is_none_for_the_root_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo with-_ ^symbols"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(&repo, "/a/repo with-_ ^symbols    (bare)".to_string());
 
@@ -83,9 +101,12 @@ fn test_path_is_none_for_the_root_list_item() {
 fn test_name_can_include_symbols() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/some-work     f9e08b4 [some-_^wo[rk]]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/some-work     f9e08b4 [some-_^wo[rk]]".to_string(),
+    );
 
     assert_eq!(Some("some-_^wo[rk]".to_string()), item.name());
 }
@@ -94,9 +115,12 @@ fn test_name_can_include_symbols() {
 fn test_name_can_include_spaces() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/some-work     f9e08b4 [some work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/some-work     f9e08b4 [some work]".to_string(),
+    );
 
     assert_eq!(Some("some work".to_string()), item.name());
 }
@@ -105,9 +129,12 @@ fn test_name_can_include_spaces() {
 fn test_name_can_include_forward_slashes() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/some-work     f9e08b4 [some/work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/some-work     f9e08b4 [some/work]".to_string(),
+    );
 
     assert_eq!(Some("some/work".to_string()), item.name());
 }
@@ -116,9 +143,12 @@ fn test_name_can_include_forward_slashes() {
 fn test_name_can_include_backslashes() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/some-work     f9e08b4 [some\\work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/some-work     f9e08b4 [some\\work]".to_string(),
+    );
 
     assert_eq!(Some("some\\work".to_string()), item.name());
 }
@@ -127,7 +157,7 @@ fn test_name_can_include_backslashes() {
 fn test_name_is_none_for_the_root_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(&repo, "/a/repo    (bare)".to_string());
 
@@ -138,7 +168,7 @@ fn test_name_is_none_for_the_root_list_item() {
 fn test_is_bare_is_true_for_the_root_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(&repo, "/a/repo    (bare)".to_string());
 
@@ -149,9 +179,12 @@ fn test_is_bare_is_true_for_the_root_list_item() {
 fn test_is_bare_is_false_for_a_non_root_list_item() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/some-work     f9e08b4 [some-work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/some-work     f9e08b4 [some-work]".to_string(),
+    );
 
     assert!(!item.is_bare());
 }
@@ -160,7 +193,7 @@ fn test_is_bare_is_false_for_a_non_root_list_item() {
 fn test_is_detached_is_true_if_list_item_is_detached() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(
         &repo,
@@ -174,9 +207,12 @@ fn test_is_detached_is_true_if_list_item_is_detached() {
 fn test_is_detached_is_false_if_list_item_is_not_detached() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
-    let item = WorktreeListItem::new(&repo, "/a/repo/some-work     f9e08b4 [some-work]".to_string());
+    let item = WorktreeListItem::new(
+        &repo,
+        "/a/repo/some-work     f9e08b4 [some-work]".to_string(),
+    );
 
     assert!(!item.is_detached());
 }
@@ -185,7 +221,7 @@ fn test_is_detached_is_false_if_list_item_is_not_detached() {
 fn test_prunable_worktree_is_parsed_properly() {
     let repo = BareRepository {
         root: PathBuf::from("/a/repo"),
-        main_branch_name: "main".to_string(),
+        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
     };
     let item = WorktreeListItem::new(
         &repo,


### PR DESCRIPTION
Tests that expected "main" to be present were failing because linux still has a default of "master". "main" is not longer hard coded in the tests, so it should work with any default set on a machine.