### PR TITLE
Simplify  and resolve build warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+## Development
+
+- Running the tests requires calling ALLOW_MAIN=1 cargo test

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,13 +11,11 @@ pub struct CommandConfiguration<'a> {
 
 #[derive(Debug)]
 pub struct SuccessfulCommandExecution {
-    pub exit_code: i32,
     pub output: Vec<String>,
 }
 
 #[derive(Debug)]
 pub struct FailedCommandExecution {
-    pub exit_code: i32,
     pub output: Vec<String>,
 }
 
@@ -57,22 +55,15 @@ pub fn run_command(config: CommandConfiguration) -> CommandExecutionResult {
 
     let result =
         output.unwrap_or_else(|_| panic!("process {:?} failed to execute", command.get_program()));
-    let exit_code = result.status.code().unwrap_or(-1);
 
     if result.status.success() {
         let stdout = String::from_utf8(result.stdout).unwrap_or_default();
         let items = remove_empty_string_elements(stdout.split('\n').collect::<Vec<&str>>());
-        Ok(SuccessfulCommandExecution {
-            exit_code,
-            output: items,
-        })
+        Ok(SuccessfulCommandExecution { output: items })
     } else {
         let stderr = String::from_utf8(result.stderr).unwrap_or_default();
         let items = remove_empty_string_elements(stderr.split('\n').collect::<Vec<&str>>());
-        Err(FailedCommandExecution {
-            exit_code,
-            output: items,
-        })
+        Err(FailedCommandExecution { output: items })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf, process::exit};
 
-use crate::utils::expand_path;
+use crate::{repository::RepositoryInterface, utils::expand_path};
 
 mod commands;
 mod repository;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -7,15 +7,15 @@ use crate::{
     utils::get_current_branch_name,
 };
 
-pub fn assert_branches(repo: &Box<dyn RepositoryInterface>, branches: Vec<String>) {
+pub fn assert_branches(repo: &Repository, branches: Vec<String>) {
     assert_eq!(all_branch_names(repo.root()), branches);
 }
 
-pub fn assert_branch_exists(repo: &Box<dyn RepositoryInterface>, branch: String) {
+pub fn assert_branch_exists(repo: &Repository, branch: String) {
     assert!(all_branch_names(repo.root()).contains(&branch));
 }
 
-pub fn assert_branch_does_not_exist(repo: &Box<dyn RepositoryInterface>, branch: String) {
+pub fn assert_branch_does_not_exist(repo: &Repository, branch: String) {
     assert!(!all_branch_names(repo.root()).contains(&branch));
 }
 
@@ -27,7 +27,7 @@ pub fn assert_worktree_does_not_exist(repo: &BareRepository, worktree_name: Stri
     assert!(!worktrees.iter().any(|w| w.name == worktree_name));
 }
 
-pub fn assert_current_branch(repo: &Box<dyn RepositoryInterface>, branch: String) {
+pub fn assert_current_branch(repo: &Repository, branch: String) {
     let current_branch = get_current_branch_name(repo.root());
 
     assert_eq!(branch, current_branch);
@@ -59,7 +59,7 @@ pub fn run_teardown(test_name: &str) {
     }
 }
 
-pub fn run_test(test_name: &str, repo_directory: &str, test: fn(Box<dyn RepositoryInterface>)) {
+pub fn run_test(test_name: &str, repo_directory: &str, test: fn(Repository)) {
     // setup must be run before we create the Repository struct or else the repo doesn't exist
     run_setup(test_name, repo_directory == BARE_REPO_NAME);
 
@@ -76,8 +76,11 @@ pub fn run_test(test_name: &str, repo_directory: &str, test: fn(Box<dyn Reposito
     run_teardown(test_name);
 }
 
-pub fn as_bare_repo(repo: &Box<dyn RepositoryInterface>) -> &BareRepository {
-    repo.as_any()
-        .downcast_ref::<BareRepository>()
-        .expect("Should have been a BareRepository, but wasn't")
+pub fn as_bare_repo(repo: &Repository) -> &BareRepository {
+    let coerced = match repo {
+        Repository::Bare(bare) => Some(bare),
+        _ => None,
+    };
+
+    coerced.expect("Should have been a BareRepository, but wasn't")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
-use std::{env, path::{PathBuf, Path}};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 use crate::commands::git_command;
 
@@ -15,7 +18,8 @@ pub fn expand_path(path: String) -> String {
 pub fn get_current_branch_name(repo_path: &Path) -> String {
     git_command(vec!["branch", "--show-current"], repo_path)
         .expect("Couldn't get current branch")
-        .output.get(0)
+        .output
+        .get(0)
         .expect("No output found")
         .to_string()
 }

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -12,10 +12,7 @@ use crate::worktree::WorktreeListItem;
 
 #[test]
 fn test_worktree_can_be_created_from_a_worktree_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string(),
@@ -28,20 +25,14 @@ fn test_worktree_can_be_created_from_a_worktree_list_item() {
 
 #[test]
 fn test_worktree_cannot_be_created_from_a_bare_worktree_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = super::WorktreeListItem::new(&repo, "/a/repo  (bare)".to_string());
     super::Worktree::try_from(item).expect_err("Shouldn't have created a worktree, but did");
 }
 
 #[test]
 fn test_worktree_cannot_be_created_from_a_detached_worktree_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = super::WorktreeListItem::new(&repo, "/a/repo  (detached HEAD)".to_string());
     super::Worktree::try_from(item).expect_err("Shouldn't have created a worktree, but did");
 }

--- a/src/worktree_list_item.rs
+++ b/src/worktree_list_item.rs
@@ -25,8 +25,12 @@ impl<'a> WorktreeListItem<'a> {
         let worktree_path = path_portion.trim();
         let absolute_path = worktree_path
             .rsplit_once(' ')
-            .unwrap_or_else(|| panic!("Couldn't split on a space, does a space exist? (string: '{}')",
-                    worktree_path))
+            .unwrap_or_else(|| {
+                panic!(
+                    "Couldn't split on a space, does a space exist? (string: '{}')",
+                    worktree_path
+                )
+            })
             .0
             .trim();
 

--- a/src/worktree_list_item/tests.rs
+++ b/src/worktree_list_item/tests.rs
@@ -12,10 +12,7 @@ use super::WorktreeListItem;
 
 #[test]
 fn test_path_output_does_not_include_repo_path() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(&repo, "/a/repo/some-work f9e08b4 [some-work]".to_string());
 
     assert_eq!(Some("/a/repo/some-work".to_string()), item.path());
@@ -23,10 +20,10 @@ fn test_path_output_does_not_include_repo_path() {
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_spaces() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo with  spaces"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(
+        DEFAULT_BRANCH_NAME.to_string(),
+        PathBuf::from("/a/repo with  spaces"),
+    );
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo with  spaces/some-work f9e08b4 [some-work]".to_string(),
@@ -40,10 +37,10 @@ fn test_path_worktree_path_and_repo_path_can_include_spaces() {
 
 #[test]
 fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo with  spaces"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(
+        DEFAULT_BRANCH_NAME.to_string(),
+        PathBuf::from("/a/repo with  spaces"),
+    );
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo with  spaces/some-work     f9e08b4 [some-work]".to_string(),
@@ -57,10 +54,10 @@ fn test_path_worktree_path_and_git_hash_can_be_separated_by_multiple_spaces() {
 
 #[test]
 fn test_path_worktree_path_and_repo_path_can_include_symbols() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo with-_ ^symbols"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(
+        DEFAULT_BRANCH_NAME.to_string(),
+        PathBuf::from("/a/repo with-_ ^symbols"),
+    );
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo with-_ ^symbols/some-work     f9e08b4 [some-work]".to_string(),
@@ -74,10 +71,7 @@ fn test_path_worktree_path_and_repo_path_can_include_symbols() {
 
 #[test]
 fn test_path_can_have_a_subdirectory() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/origin/some-work     f9e08b4 [some-work]".to_string(),
@@ -88,10 +82,10 @@ fn test_path_can_have_a_subdirectory() {
 
 #[test]
 fn test_path_is_none_for_the_root_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo with-_ ^symbols"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(
+        DEFAULT_BRANCH_NAME.to_string(),
+        PathBuf::from("/a/repo with-_ ^symbols"),
+    );
     let item = WorktreeListItem::new(&repo, "/a/repo with-_ ^symbols    (bare)".to_string());
 
     assert_eq!(None, item.path());
@@ -99,10 +93,7 @@ fn test_path_is_none_for_the_root_list_item() {
 
 #[test]
 fn test_name_can_include_symbols() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some-work     f9e08b4 [some-_^wo[rk]]".to_string(),
@@ -113,10 +104,7 @@ fn test_name_can_include_symbols() {
 
 #[test]
 fn test_name_can_include_spaces() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some-work     f9e08b4 [some work]".to_string(),
@@ -127,10 +115,7 @@ fn test_name_can_include_spaces() {
 
 #[test]
 fn test_name_can_include_forward_slashes() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some-work     f9e08b4 [some/work]".to_string(),
@@ -141,10 +126,7 @@ fn test_name_can_include_forward_slashes() {
 
 #[test]
 fn test_name_can_include_backslashes() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some-work     f9e08b4 [some\\work]".to_string(),
@@ -155,10 +137,7 @@ fn test_name_can_include_backslashes() {
 
 #[test]
 fn test_name_is_none_for_the_root_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(&repo, "/a/repo    (bare)".to_string());
 
     assert_eq!(None, item.name());
@@ -166,10 +145,7 @@ fn test_name_is_none_for_the_root_list_item() {
 
 #[test]
 fn test_is_bare_is_true_for_the_root_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(&repo, "/a/repo    (bare)".to_string());
 
     assert!(item.is_bare());
@@ -177,10 +153,7 @@ fn test_is_bare_is_true_for_the_root_list_item() {
 
 #[test]
 fn test_is_bare_is_false_for_a_non_root_list_item() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some-work     f9e08b4 [some-work]".to_string(),
@@ -191,10 +164,7 @@ fn test_is_bare_is_false_for_a_non_root_list_item() {
 
 #[test]
 fn test_is_detached_is_true_if_list_item_is_detached() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/dirty                0000000 (detached HEAD)".to_string(),
@@ -205,10 +175,7 @@ fn test_is_detached_is_true_if_list_item_is_detached() {
 
 #[test]
 fn test_is_detached_is_false_if_list_item_is_not_detached() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some-work     f9e08b4 [some-work]".to_string(),
@@ -219,10 +186,7 @@ fn test_is_detached_is_false_if_list_item_is_not_detached() {
 
 #[test]
 fn test_prunable_worktree_is_parsed_properly() {
-    let repo = BareRepository {
-        root: PathBuf::from("/a/repo"),
-        main_branch_name: DEFAULT_BRANCH_NAME.to_string(),
-    };
+    let repo = BareRepository::new(DEFAULT_BRANCH_NAME.to_string(), PathBuf::from("/a/repo"));
     let item = WorktreeListItem::new(
         &repo,
         "/a/repo/some  work in a prunable worktree    f9e08b4 [some-work] prunable".to_string(),


### PR DESCRIPTION
This pull request introduces several changes to improve code maintainability, simplify repository handling, and enhance test coverage. The most significant updates include refactoring the `Repository` structure, removing unused fields, and updating test cases to align with the new structure.

### Repository Refactor and Simplification:
* Refactored `Repository` into an enum with two variants: `Bare` and `Normal`, replacing the previous trait object-based design. Updated methods in `RepositoryInterface` to delegate behavior based on the variant. (`src/repository.rs`, [[1]](diffhunk://#diff-a996099d93cf2fb61dd8897d271295028c908d03dd0d6d56026cddbb24ac7ccbL18-R67) [[2]](diffhunk://#diff-a996099d93cf2fb61dd8897d271295028c908d03dd0d6d56026cddbb24ac7ccbL228-R269) [[3]](diffhunk://#diff-a996099d93cf2fb61dd8897d271295028c908d03dd0d6d56026cddbb24ac7ccbL237-R292)
* Removed the `as_any` method from `RepositoryInterface` and shifted type-specific logic into the `Repository` enum. (`src/repository.rs`, [[1]](diffhunk://#diff-a996099d93cf2fb61dd8897d271295028c908d03dd0d6d56026cddbb24ac7ccbL78-L81) [[2]](diffhunk://#diff-0f0187388bbf7a0675ff20f129873ed29168a5b3ded57ea8bff6e6a5359633c0L79-R85)

### Command Execution Updates:
* Removed the `exit_code` field from `SuccessfulCommandExecution` and `FailedCommandExecution`, as it was unused. Updated the `run_command` function to reflect this change. (`src/commands.rs`, [[1]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L14-L20) [[2]](diffhunk://#diff-b86d43fce6a9c57160aa925719550d40a6ed3f5e5a0117679905f76e68acc520L60-R66)

### Test Case Updates:
* Updated test cases to use the new `Repository` enum instead of `Box<dyn RepositoryInterface>`. Added helper constructors (`new`) for `BareRepository` and `NormalRepository` to simplify test setup. (`src/test_helpers.rs`, [[1]](diffhunk://#diff-0f0187388bbf7a0675ff20f129873ed29168a5b3ded57ea8bff6e6a5359633c0L10-R18) [[2]](diffhunk://#diff-42e5cb67d5d49a857b36a9066d431a3400dda0bf7d584e3a27439c6cdbf5d7ffL15-R15) [[3]](diffhunk://#diff-4ba6bd72c98ff72bbc777fe7d1b0a00bbb3401d2aa723b4e51c5a3b42bcd01bbL15-R26)

### Code Cleanup:
* Removed unnecessary imports and reorganized `use` statements for better readability. (`src/repository.rs`, [[1]](diffhunk://#diff-a996099d93cf2fb61dd8897d271295028c908d03dd0d6d56026cddbb24ac7ccbL1-R1) `src/utils.rs`, [[2]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L1-R4)

### Minor Improvements:
* Added a note in the `CLAUDE.md` file about running tests with the `ALLOW_MAIN=1` environment variable. (`CLAUDE.md`, [CLAUDE.mdR1-R3](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R3))