### PR TITLE
Remove RepositoryInterface trait and simplify architecture

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf, process::exit};
 
-use crate::{repository::RepositoryInterface, utils::expand_path};
+use crate::utils::expand_path;
 
 mod commands;
 mod repository;

--- a/src/repository/tests.rs
+++ b/src/repository/tests.rs
@@ -8,7 +8,7 @@ use std::fs::create_dir;
 use std::path::PathBuf;
 
 #[cfg(test)]
-use crate::repository::{all_branch_names, RepositoryInterface};
+use crate::repository::all_branch_names;
 
 #[cfg(test)]
 use crate::repository::{BareRepository, NormalRepository};
@@ -31,7 +31,7 @@ fn test_repository_at_returns_a_bare_repository_for_the_bare_root_path() {
         "test_repository_at_returns_a_bare_repository_for_the_bare_root_path",
         BARE_REPO_NAME,
         |repo| match Repository::at(repo.root()) {
-            Some(r) => assert!(r.is_bare()),
+            Some(r) => assert!(matches!(r, Repository::Bare(_))),
             _ => panic!("Should have returned a BareRepository, but didn't"),
         },
     );
@@ -43,7 +43,7 @@ fn test_repository_at_returns_a_bare_repository_for_a_valid_repo_subdirectory_pa
         "test_repository_at_returns_a_bare_repository_for_a_valid_repo_subdirectory_path",
         BARE_REPO_NAME,
         |repo| match Repository::at(&repo.root().join("merged")) {
-            Some(r) => assert!(r.is_bare()),
+            Some(r) => assert!(matches!(r, Repository::Bare(_))),
             _ => panic!("Should have returned a BareRepository, but didn't"),
         },
     );
@@ -55,7 +55,7 @@ fn test_repository_at_returns_a_normal_repository() {
         "test_repository_at_returns_a_normal_repository",
         CLEAN_NORMAL_REPO_NAME,
         |repo| match Repository::at(repo.root()) {
-            Some(r) => assert!(!r.is_bare()),
+            Some(r) => assert!(!matches!(r, Repository::Bare(_))),
             _ => panic!("Should have returned a BareRepository, but didn't"),
         },
     );
@@ -117,10 +117,7 @@ fn test_bare_repository_at_with_subdirectory_has_correct_main_branch_name() {
             let repo2 = BareRepository::at(&path)
                 .unwrap_or_else(|| panic!("{:#?} is not a valid git repository", &path));
 
-            assert_eq!(
-                DEFAULT_BRANCH_NAME,
-                RepositoryInterface::main_branch_name(&repo2)
-            );
+            assert_eq!(DEFAULT_BRANCH_NAME, repo2.main_branch_name());
         },
     );
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,7 +1,5 @@
 use crate::{
-    commands::git_command,
-    repository::{BareRepository, RepositoryInterface},
-    worktree_list_item::WorktreeListItem,
+    commands::git_command, repository::BareRepository, worktree_list_item::WorktreeListItem,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,16 +33,13 @@ impl<'a> Worktree<'a> {
     pub fn delete(&self) -> Result<(), String> {
         match git_command(
             vec!["worktree", "remove", &self.path],
-            RepositoryInterface::root(self.repository),
+            self.repository.root(),
         ) {
             Ok(_) => Ok(()),
             Err(result) => Err(result.output.join(",")),
         }?;
 
-        match git_command(
-            vec!["branch", "-d", &self.name],
-            RepositoryInterface::root(self.repository),
-        ) {
+        match git_command(vec!["branch", "-d", &self.name], self.repository.root()) {
             Ok(_) => Ok(()),
             Err(result) => Err(result.output.join(",")),
         }
@@ -53,7 +48,7 @@ impl<'a> Worktree<'a> {
     pub fn is_clean(&self) -> bool {
         let result = git_command(
             vec!["status", "--short"],
-            &RepositoryInterface::root(self.repository).join(&self.path),
+            &self.repository.root().join(&self.path),
         );
 
         match result {


### PR DESCRIPTION
### 💡 What it is

Eliminated the RepositoryInterface trait by moving methods directly to the Repository enum and individual struct implementations.

### ❓ Why

The trait added unnecessary complexity and indirection when the enum pattern already provides clean type-safe delegation to the appropriate repository variant.

### 🔧 How

- Moved `clean_merged()` method to Repository enum with delegation to private `_impl` methods
- Added direct field access methods to BareRepository for worktree operations  
- Updated all callers to use the simplified Repository interface
- Removed trait implementations and the trait itself

### 🧪 Testing

All existing tests pass with the new architecture, confirming functionality is preserved while reducing complexity.

🤖 Generated with [Claude Code](https://claude.ai/code)